### PR TITLE
update org.activiti.cloud.dependencies:activiti-cloud-dependencies to 7.1.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Activiti Cloud :: Activiti Ranking Cloud Connector</name>
 	<properties>
     <java.version>11</java.version>
-    <activiti-cloud-dependencies.version>7.1.82</activiti-cloud-dependencies.version>
+    <activiti-cloud-dependencies.version>7.1.83</activiti-cloud-dependencies.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.dependencies:activiti-cloud-dependencies` to: `7.1.83`